### PR TITLE
fix: redirect unregistered users to the login page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import SignUp from './pages/SignUp';
 import Results from './pages/Results';
 import {Routes, Route} from "react-router-dom";
 import { AuthContextProvider } from './context/AuthContext';
+import ProtectedRoute from './components/ProtectedRoute';
 
 function App() {
   return (
@@ -16,8 +17,8 @@ function App() {
           <Route path="/" element={<Home/>} />
           <Route path="/login" element={<Login/>} />
           <Route path="/signup" element={<SignUp/>} />
-          <Route path="/play" element ={<Play/>} />
-          <Route path="/results" element={<Results/>} />
+          <Route path="/play" element ={<ProtectedRoute>  <Play/> </ProtectedRoute>} />
+          <Route path="/results" element={<ProtectedRoute> <Results/> </ProtectedRoute>} />
         </Routes>
         </AuthContextProvider>
     </div>

--- a/frontend/src/components/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import {Navigate} from 'react-router-dom';
+import { UserAuth } from '../context/AuthContext';
+
+export default function ProtectedRoute({children}) {
+  const { user } = UserAuth();
+  
+  if (!user) {
+    return <Navigate to='/login'/>
+  }
+  return children
+}
+
+

--- a/frontend/src/pages/SignUp.js
+++ b/frontend/src/pages/SignUp.js
@@ -15,7 +15,7 @@ export default function SignUp() {
     e.preventDefault();
     try {
       await createUser(email,password);
-      navigate('/home')
+      navigate('/')
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
If a user has not logged in or registered, they can't access the Play or Results page. After they have logged in, they can access both of the respective pages. 